### PR TITLE
Location screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -228,7 +228,8 @@ export default class App extends React.Component {
       checkInsEvents: { data: [] },
       givingFunds: { data: [] },
       groups: groups,
-      registrationsEvents: { data: [] }
+      registrationsEvents: { data: [] },
+      locationPermission: false,
     };
   }
 

--- a/App.js
+++ b/App.js
@@ -16,6 +16,7 @@ import { HomeScreen } from "./modules/HomeScreen";
 import { ProfileScreen } from "./modules/ProfileScreen";
 import {
   LocationScreen,
+  LocationList,
 } from "./modules/LocationScreen";
 
 import Ionicons from "react-native-vector-icons/Ionicons";

--- a/App.js
+++ b/App.js
@@ -30,6 +30,28 @@ headers.append("Authorization", `Basic ${TOKEN}`);
 
 const Navigation = TabNavigator(
   {
+    Location: {
+      screen: StackNavigator({
+        Location: {
+          screen: LocationScreen
+        },
+        LocationList: {
+          screen: LocationList
+        },
+      }),
+      navigationOptions: {
+        tabBarLabel: "Location",
+        tabBarIcon: ({ tintColor, focused }) => (
+          <Ionicons
+            name={
+              focused ? "ios-locate" : "ios-locate-outline"
+            }
+            size={26}
+            style={{ color: tintColor }}
+          />
+        )
+      }
+    },
     Give: {
       screen: StackNavigator({
         // GiveHome: {

--- a/App.js
+++ b/App.js
@@ -228,8 +228,7 @@ export default class App extends React.Component {
       checkInsEvents: { data: [] },
       givingFunds: { data: [] },
       groups: groups,
-      registrationsEvents: { data: [] },
-      locationPermission: false,
+      registrationsEvents: { data: [] }
     };
   }
 

--- a/App.js
+++ b/App.js
@@ -14,6 +14,9 @@ import {
 import { GroupsScreen, ShowGroup } from "./modules/GroupsScreen";
 import { HomeScreen } from "./modules/HomeScreen";
 import { ProfileScreen } from "./modules/ProfileScreen";
+import {
+  LocationScreen,
+} from "./modules/LocationScreen";
 
 import Ionicons from "react-native-vector-icons/Ionicons";
 

--- a/modules/LocationScreen.js
+++ b/modules/LocationScreen.js
@@ -1,0 +1,86 @@
+import React from "react";
+import { Avatar, Icon } from 'react-native-elements';
+import Ionicons from "react-native-vector-icons/Ionicons";
+
+import {
+  StyleSheet,
+  View,
+  Text,
+  Button,
+  TextInput,
+  FlatList
+} from "react-native";
+
+export class LocationScreen extends React.Component {
+  static navigationOptions = {
+    title: "Location"
+  };
+
+  render() {
+      return (
+        <View
+          style={{
+            flex: 1,
+            backgroundColor: "#fff",
+          }}>
+          <View
+            style={{
+              height: 350,
+              alignItems: "center",
+              justifyContent: "flex-end",
+            }}>
+            <View
+              style={{
+                alignItems: "center",
+                marginBottom: 16,
+              }}>
+              <Ionicons
+                name="ios-pin-outline"
+                color="#007aff"
+                size={80}
+                style={{
+                  backgroundColor: "transparent"
+                }}
+              />
+              <View
+                style={{
+                  backgroundColor: "#00000020",
+                  width: 50,
+                  height: 50,
+                  borderRadius: 50,
+                  position: "absolute",
+                  bottom: 0,
+                  transform: [
+                    { scaleY: 0.2 },
+                    { translateY: 42 },
+                  ],
+                  zIndex: -1,
+                }}>
+              </View>
+            </View>
+            <View>
+              <Text
+                style={{
+                  fontSize: 16,
+                  fontWeight: "bold",
+                  color: "#585756",
+                  textAlign: "center",
+                  marginBottom: 8,
+                }}>
+                Find Your Church
+              </Text>
+              <Text
+                style={{
+                  color: "#878685",
+                  textAlign: "center",
+                  maxWidth: 220,
+                }}
+              >
+                Church Center uses your location to search for nearby churches.
+              </Text>
+            </View>
+          </View>
+        </View>
+      )
+  }
+}

--- a/modules/LocationScreen.js
+++ b/modules/LocationScreen.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Avatar, Icon } from 'react-native-elements';
+import { Avatar, Icon, List, ListItem } from 'react-native-elements';
 import Ionicons from "react-native-vector-icons/Ionicons";
 import FontAwesome from "react-native-vector-icons/FontAwesome";
 
@@ -165,6 +165,39 @@ export class LocationList extends React.Component {
   render() {
     const { navigate } = this.props.navigation;
 
+    const list = [
+      {
+        title: "C3 Church San Diego North Campus",
+        address: "2716 Gateway Rd",
+        city: "Carlsbad",
+      },
+      {
+        title: "St. Katherine Orthodox Church",
+        address: "2720 Loker Ave W",
+        city: "Carlsbad",
+      },
+      {
+        title: "Holy Cross Episcopal Church",
+        address: "2510 Gateway Rd",
+        city: "Carlsbad",
+      },
+      {
+        title: "Faith Community Church",
+        address: "2700 Rancho Pancho",
+        city: "Carlsbad",
+      },
+      {
+        title: "North Coast Church Carlsbad",
+        address: "6515 Ambrosia Ln",
+        city: "Carlsbad",
+      },
+      {
+        title: "Daybreak Community Church",
+        address: "6515 Ambrosia Ln",
+        city: "Carlsbad",
+      },
+    ]
+
     return (
       <View
         style={{
@@ -172,7 +205,56 @@ export class LocationList extends React.Component {
           alignItems: "center",
           backgroundColor: "#fff",
         }}>
-        <Text>Uh, stuff goes here!</Text>
+        <View
+          style={{
+            padding: 16,
+            paddingBottom: 0,
+            width: "100%",
+          }}>
+          <TextInput
+            placeholder="Name of church"
+            style={{
+              color: "#878685",
+              padding: 8,
+              borderWidth: 1,
+              borderColor: "#ddd",
+              borderStyle: "solid",
+              borderRadius: 3,
+              marginBottom: 4,
+            }}
+            returnKeyType="search"
+          />
+          <TextInput
+            placeholder="City, State or Zip Code"
+            value="92009"
+            style={{
+              color: "#878685",
+              padding: 8,
+              borderWidth: 1,
+              borderColor: "#ddd",
+              borderStyle: "solid",
+              borderRadius: 3,
+            }}
+            returnKeyType="search"
+          />
+        </View>
+        <List
+          containerStyle={{
+            width: "100%"
+          }}>
+          {
+            list.map((item, i) => (
+              <ListItem
+                key={i}
+                title={item.title}
+                subtitle={`${item.address}, ${item.city}`}
+                style={{ borderBottomColor: "#000000" }}
+                titleStyle={{ fontSize: 16, color: "#585756" }}
+                subtitleStyle={{ fontSize: 14, fontWeight: "normal", color: "#878685" }}
+              />
+            ))
+          }
+        </List>
       </View>
     )
   }

--- a/modules/LocationScreen.js
+++ b/modules/LocationScreen.js
@@ -9,7 +9,9 @@ import {
   Text,
   Button,
   TextInput,
-  FlatList
+  FlatList,
+  Keyboard,
+  KeyboardAvoidingView,
 } from "react-native";
 
 export class LocationScreen extends React.Component {
@@ -19,118 +21,121 @@ export class LocationScreen extends React.Component {
 
   render() {
       return (
-        <View
+        <KeyboardAvoidingView
+          behavior="position"
           style={{
             flex: 1,
             alignItems: "center",
             backgroundColor: "#fff",
           }}>
-          <View
-            style={{
-              height: 300,
-              alignItems: "center",
-              justifyContent: "flex-end",
-            }}>
+            <View
+              style={{
+                height: 300,
+                alignItems: "center",
+                justifyContent: "flex-end",
+              }}>
+              <View
+                style={{
+                  alignItems: "center",
+                  marginBottom: 16,
+                }}>
+                <Ionicons
+                  name="ios-pin-outline"
+                  color="#61ba66"
+                  size={80}
+                  style={{
+                    backgroundColor: "transparent"
+                  }}
+                />
+                <View
+                  style={{
+                    backgroundColor: "#00000010",
+                    width: 50,
+                    height: 50,
+                    borderRadius: 50,
+                    position: "absolute",
+                    bottom: 0,
+                    transform: [
+                      { scaleY: 0.2 },
+                      { translateY: 42 },
+                    ],
+                    zIndex: -1,
+                  }}>
+                </View>
+              </View>
+            </View>
             <View
               style={{
                 alignItems: "center",
-                marginBottom: 16,
+                maxWidth: 220,
               }}>
-              <Ionicons
-                name="ios-pin-outline"
-                color="#61ba66"
-                size={80}
-                style={{
-                  backgroundColor: "transparent"
-                }}
-              />
-              <View
-                style={{
-                  backgroundColor: "#00000010",
-                  width: 50,
-                  height: 50,
-                  borderRadius: 50,
-                  position: "absolute",
-                  bottom: 0,
-                  transform: [
-                    { scaleY: 0.2 },
-                    { translateY: 42 },
-                  ],
-                  zIndex: -1,
-                }}>
-              </View>
-            </View>
-          </View>
-          <View
-            style={{
-              alignItems: "center",
-              maxWidth: 220,
-            }}>
-            <Text
-              style={{
-                fontSize: 16,
-                fontWeight: "bold",
-                color: "#585756",
-                textAlign: "center",
-                marginBottom: 8,
-              }}>
-              Find Your Church
-            </Text>
-            <Text
-              style={{
-                color: "#878685",
-                textAlign: "center",
-              }}
-            >
-              Church Center uses your location to search for nearby churches.
-            </Text>
-            <View
-              style={{
-                marginTop: 32
-              }}>
-              <TextInput
-                placeholder="Enter zip code"
-                style={{
-                  color: "#878685",
-                  padding: 16,
-                  borderWidth: 1,
-                  borderColor: "#ddd",
-                  borderStyle: "solid",
-                  borderRadius: 3,
-                }}
-              />
               <Text
                 style={{
-                  color: "#87868550",
-                  marginTop: 8,
+                  fontSize: 16,
+                  fontWeight: "bold",
+                  color: "#585756",
+                  textAlign: "center",
                   marginBottom: 8,
-                  textAlign: "center"
                 }}>
-                or
+                Find Your Church
+              </Text>
+              <Text
+                style={{
+                  color: "#878685",
+                  textAlign: "center",
+                }}
+              >
+                Church Center uses your location to search for nearby churches.
               </Text>
               <View
                 style={{
-                  flexDirection: "row"
+                  marginTop: 32
                 }}>
-                <FontAwesome
-                  name="location-arrow"
-                  color="#007aff"
-                  size={16}
+                <TextInput
+                  placeholder="Enter zip code"
                   style={{
-                    backgroundColor: "transparent",
-                    marginRight: 8,
+                    color: "#878685",
+                    padding: 16,
+                    borderWidth: 1,
+                    borderColor: "#ddd",
+                    borderStyle: "solid",
+                    borderRadius: 3,
                   }}
+                  keyboardType="numeric"
+                  returnKeyType="done"
                 />
                 <Text
                   style={{
-                    color: "#007aff"
+                    color: "#87868550",
+                    marginTop: 8,
+                    marginBottom: 8,
+                    textAlign: "center"
                   }}>
-                  Use current location
+                  or
                 </Text>
+                <View
+                  style={{
+                    flexDirection: "row"
+                  }}>
+                  <FontAwesome
+                    name="location-arrow"
+                    color="#007aff"
+                    size={16}
+                    style={{
+                      backgroundColor: "transparent",
+                      marginRight: 8,
+                    }}
+                  />
+                  <Text
+                    style={{
+                      color: "#007aff"
+                    }}>
+                    Use current location
+                  </Text>
+                </View>
               </View>
             </View>
-          </View>
-        </View>
+        </KeyboardAvoidingView>
       )
   }
 }

--- a/modules/LocationScreen.js
+++ b/modules/LocationScreen.js
@@ -21,6 +21,10 @@ export class LocationScreen extends React.Component {
     title: "Location"
   };
 
+  state = {
+    zip: null,
+  }
+
   render() {
     const { navigate } = this.props.navigation;
 
@@ -108,7 +112,11 @@ export class LocationScreen extends React.Component {
                 maxLength={5}
                 keyboardType="numeric"
                 returnKeyType="done"
-                onSubmitEditing={(event) => navigate("LocationList")}
+                onChangeText={(text) => this.setState({text})}
+                onSubmitEditing={(event) => navigate("LocationList", {
+                                              locationPermission: false,
+                                              zip: this.state.text
+                                            })}
               />
               <Text
                 style={{
@@ -129,7 +137,15 @@ export class LocationScreen extends React.Component {
                     "This app needs your location to search for nearby churches.",
                     [
                       {text: "Don’t Allow"},
-                      {text: "Allow", onPress: () => navigate("LocationList")}
+                      {
+                        text: "Allow",
+                        onPress: () => {
+                          navigate("LocationList", {
+                            locationPermission: true,
+                            zip: null
+                          });
+                        }
+                      }
                     ]
                   )}
                 >
@@ -164,6 +180,7 @@ export class LocationList extends React.Component {
 
   render() {
     const { navigate } = this.props.navigation;
+    const locationPermission = this.props.navigation.state.params.locationPermission
 
     const list = [
       {
@@ -226,9 +243,10 @@ export class LocationList extends React.Component {
           />
           <TextInput
             placeholder="City, State or Zip Code"
-            value="92009"
+            value={ locationPermission ? "Current location" : this.props.navigation.state.params.zip }
             style={{
-              color: "#878685",
+              fontWeight: locationPermission ? "bold" : "normal",
+              color: locationPermission ? "#007aff" : "#878685",
               padding: 8,
               borderWidth: 1,
               borderColor: "#ddd",

--- a/modules/LocationScreen.js
+++ b/modules/LocationScreen.js
@@ -12,6 +12,7 @@ import {
   FlatList,
   Keyboard,
   KeyboardAvoidingView,
+  TouchableOpacity,
 } from "react-native";
 
 export class LocationScreen extends React.Component {
@@ -20,6 +21,8 @@ export class LocationScreen extends React.Component {
   };
 
   render() {
+    const { navigate } = this.props.navigation;
+
     return (
       <KeyboardAvoidingView
         behavior="position"
@@ -113,29 +116,53 @@ export class LocationScreen extends React.Component {
                 }}>
                 or
               </Text>
-              <View
-                style={{
-                  flexDirection: "row"
-                }}>
-                <FontAwesome
-                  name="location-arrow"
-                  color="#007aff"
-                  size={16}
+              <View>
+                <TouchableOpacity
                   style={{
-                    backgroundColor: "transparent",
-                    marginRight: 8,
+                    flexDirection: "row"
                   }}
-                />
-                <Text
-                  style={{
-                    color: "#007aff"
-                  }}>
-                  Use current location
-                </Text>
+                  onPress={() => navigate("LocationList")}
+                >
+                  <FontAwesome
+                    name="location-arrow"
+                    color="#007aff"
+                    size={16}
+                    style={{
+                      backgroundColor: "transparent",
+                      marginRight: 8,
+                    }}
+                  />
+                  <Text
+                    style={{
+                      color: "#007aff"
+                    }}>
+                    Use current location
+                  </Text>
+                </TouchableOpacity>
               </View>
             </View>
           </View>
       </KeyboardAvoidingView>
+    )
+  }
+}
+
+export class LocationList extends React.Component {
+  static navigationOptions = {
+    title: "Nearby Churches"
+  };
+
+  render() {
+    const { navigate } = this.props.navigation;
+
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: "center",
+          backgroundColor: "#fff",
+        }}>
+      </View>
     )
   }
 }

--- a/modules/LocationScreen.js
+++ b/modules/LocationScreen.js
@@ -13,6 +13,7 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   TouchableOpacity,
+  Alert,
 } from "react-native";
 
 export class LocationScreen extends React.Component {
@@ -121,7 +122,14 @@ export class LocationScreen extends React.Component {
                   style={{
                     flexDirection: "row"
                   }}
-                  onPress={() => navigate("LocationList")}
+                  onPress={() => Alert.alert(
+                    "Allow Church Center to access your location while you are using the app?",
+                    "This app needs your location to search for nearby churches.",
+                    [
+                      {text: "Don’t Allow"},
+                      {text: "Allow", onPress: () => navigate("LocationList")}
+                    ]
+                  )}
                 >
                   <FontAwesome
                     name="location-arrow"

--- a/modules/LocationScreen.js
+++ b/modules/LocationScreen.js
@@ -20,122 +20,122 @@ export class LocationScreen extends React.Component {
   };
 
   render() {
-      return (
-        <KeyboardAvoidingView
-          behavior="position"
-          style={{
-            flex: 1,
-            alignItems: "center",
-            backgroundColor: "#fff",
-          }}>
+    return (
+      <KeyboardAvoidingView
+        behavior="position"
+        style={{
+          flex: 1,
+          alignItems: "center",
+          backgroundColor: "#fff",
+        }}>
+          <View
+            style={{
+              height: 300,
+              alignItems: "center",
+              justifyContent: "flex-end",
+            }}>
             <View
               style={{
-                height: 300,
                 alignItems: "center",
-                justifyContent: "flex-end",
+                marginBottom: 16,
               }}>
+              <Ionicons
+                name="ios-pin-outline"
+                color="#61ba66"
+                size={80}
+                style={{
+                  backgroundColor: "transparent"
+                }}
+              />
               <View
                 style={{
-                  alignItems: "center",
-                  marginBottom: 16,
+                  backgroundColor: "#00000010",
+                  width: 50,
+                  height: 50,
+                  borderRadius: 50,
+                  position: "absolute",
+                  bottom: 0,
+                  transform: [
+                    { scaleY: 0.2 },
+                    { translateY: 42 },
+                  ],
+                  zIndex: -1,
                 }}>
-                <Ionicons
-                  name="ios-pin-outline"
-                  color="#61ba66"
-                  size={80}
-                  style={{
-                    backgroundColor: "transparent"
-                  }}
-                />
-                <View
-                  style={{
-                    backgroundColor: "#00000010",
-                    width: 50,
-                    height: 50,
-                    borderRadius: 50,
-                    position: "absolute",
-                    bottom: 0,
-                    transform: [
-                      { scaleY: 0.2 },
-                      { translateY: 42 },
-                    ],
-                    zIndex: -1,
-                  }}>
-                </View>
               </View>
             </View>
+          </View>
+          <View
+            style={{
+              alignItems: "center",
+              maxWidth: 220,
+            }}>
+            <Text
+              style={{
+                fontSize: 16,
+                fontWeight: "bold",
+                color: "#585756",
+                textAlign: "center",
+                marginBottom: 8,
+              }}>
+              Find Your Church
+            </Text>
+            <Text
+              style={{
+                color: "#878685",
+                textAlign: "center",
+              }}
+            >
+              Church Center uses your location to search for nearby churches.
+            </Text>
             <View
               style={{
-                alignItems: "center",
-                maxWidth: 220,
+                marginTop: 32
               }}>
-              <Text
-                style={{
-                  fontSize: 16,
-                  fontWeight: "bold",
-                  color: "#585756",
-                  textAlign: "center",
-                  marginBottom: 8,
-                }}>
-                Find Your Church
-              </Text>
-              <Text
+              <TextInput
+                placeholder="Enter zip code"
                 style={{
                   color: "#878685",
-                  textAlign: "center",
+                  padding: 16,
+                  borderWidth: 1,
+                  borderColor: "#ddd",
+                  borderStyle: "solid",
+                  borderRadius: 3,
                 }}
-              >
-                Church Center uses your location to search for nearby churches.
+                keyboardType="numeric"
+                returnKeyType="done"
+              />
+              <Text
+                style={{
+                  color: "#87868550",
+                  marginTop: 8,
+                  marginBottom: 8,
+                  textAlign: "center"
+                }}>
+                or
               </Text>
               <View
                 style={{
-                  marginTop: 32
+                  flexDirection: "row"
                 }}>
-                <TextInput
-                  placeholder="Enter zip code"
+                <FontAwesome
+                  name="location-arrow"
+                  color="#007aff"
+                  size={16}
                   style={{
-                    color: "#878685",
-                    padding: 16,
-                    borderWidth: 1,
-                    borderColor: "#ddd",
-                    borderStyle: "solid",
-                    borderRadius: 3,
+                    backgroundColor: "transparent",
+                    marginRight: 8,
                   }}
-                  keyboardType="numeric"
-                  returnKeyType="done"
                 />
                 <Text
                   style={{
-                    color: "#87868550",
-                    marginTop: 8,
-                    marginBottom: 8,
-                    textAlign: "center"
+                    color: "#007aff"
                   }}>
-                  or
+                  Use current location
                 </Text>
-                <View
-                  style={{
-                    flexDirection: "row"
-                  }}>
-                  <FontAwesome
-                    name="location-arrow"
-                    color="#007aff"
-                    size={16}
-                    style={{
-                      backgroundColor: "transparent",
-                      marginRight: 8,
-                    }}
-                  />
-                  <Text
-                    style={{
-                      color: "#007aff"
-                    }}>
-                    Use current location
-                  </Text>
-                </View>
               </View>
             </View>
-        </KeyboardAvoidingView>
-      )
+          </View>
+      </KeyboardAvoidingView>
+    )
   }
 }

--- a/modules/LocationScreen.js
+++ b/modules/LocationScreen.js
@@ -105,8 +105,10 @@ export class LocationScreen extends React.Component {
                   borderStyle: "solid",
                   borderRadius: 3,
                 }}
+                maxLength={5}
                 keyboardType="numeric"
                 returnKeyType="done"
+                onSubmitEditing={(event) => navigate("LocationList")}
               />
               <Text
                 style={{

--- a/modules/LocationScreen.js
+++ b/modules/LocationScreen.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Avatar, Icon } from 'react-native-elements';
 import Ionicons from "react-native-vector-icons/Ionicons";
+import FontAwesome from "react-native-vector-icons/FontAwesome";
 
 import {
   StyleSheet,
@@ -21,11 +22,12 @@ export class LocationScreen extends React.Component {
         <View
           style={{
             flex: 1,
+            alignItems: "center",
             backgroundColor: "#fff",
           }}>
           <View
             style={{
-              height: 350,
+              height: 300,
               alignItems: "center",
               justifyContent: "flex-end",
             }}>
@@ -36,7 +38,7 @@ export class LocationScreen extends React.Component {
               }}>
               <Ionicons
                 name="ios-pin-outline"
-                color="#007aff"
+                color="#61ba66"
                 size={80}
                 style={{
                   backgroundColor: "transparent"
@@ -44,7 +46,7 @@ export class LocationScreen extends React.Component {
               />
               <View
                 style={{
-                  backgroundColor: "#00000020",
+                  backgroundColor: "#00000010",
                   width: 50,
                   height: 50,
                   borderRadius: 50,
@@ -58,26 +60,74 @@ export class LocationScreen extends React.Component {
                 }}>
               </View>
             </View>
-            <View>
-              <Text
-                style={{
-                  fontSize: 16,
-                  fontWeight: "bold",
-                  color: "#585756",
-                  textAlign: "center",
-                  marginBottom: 8,
-                }}>
-                Find Your Church
-              </Text>
-              <Text
+          </View>
+          <View
+            style={{
+              alignItems: "center",
+              maxWidth: 220,
+            }}>
+            <Text
+              style={{
+                fontSize: 16,
+                fontWeight: "bold",
+                color: "#585756",
+                textAlign: "center",
+                marginBottom: 8,
+              }}>
+              Find Your Church
+            </Text>
+            <Text
+              style={{
+                color: "#878685",
+                textAlign: "center",
+              }}
+            >
+              Church Center uses your location to search for nearby churches.
+            </Text>
+            <View
+              style={{
+                marginTop: 32
+              }}>
+              <TextInput
+                placeholder="Enter zip code"
                 style={{
                   color: "#878685",
-                  textAlign: "center",
-                  maxWidth: 220,
+                  padding: 16,
+                  borderWidth: 1,
+                  borderColor: "#ddd",
+                  borderStyle: "solid",
+                  borderRadius: 3,
                 }}
-              >
-                Church Center uses your location to search for nearby churches.
+              />
+              <Text
+                style={{
+                  color: "#87868550",
+                  marginTop: 8,
+                  marginBottom: 8,
+                  textAlign: "center"
+                }}>
+                or
               </Text>
+              <View
+                style={{
+                  flexDirection: "row"
+                }}>
+                <FontAwesome
+                  name="location-arrow"
+                  color="#007aff"
+                  size={16}
+                  style={{
+                    backgroundColor: "transparent",
+                    marginRight: 8,
+                  }}
+                />
+                <Text
+                  style={{
+                    color: "#007aff"
+                  }}>
+                  Use current location
+                </Text>
+              </View>
             </View>
           </View>
         </View>

--- a/modules/LocationScreen.js
+++ b/modules/LocationScreen.js
@@ -170,6 +170,7 @@ export class LocationList extends React.Component {
           alignItems: "center",
           backgroundColor: "#fff",
         }}>
+        <Text>Uh, stuff goes here!</Text>
       </View>
     )
   }


### PR DESCRIPTION
## What
Screens to demonstrate basic flow of location select and location list with dummy data.

### Notes:
For now I shoe-horned the location icon in the bottom nav so we can access the screen, but my guess is it’d ideally be accessible via another way.

I got stuck trying to set and update the `appState` to set `zip` and `locationPermission` so instead passing them as params via `navigate()`: https://github.com/planningcenter/church-center-dreamin/pull/1/commits/aa31e36118f8cf98a10e2b282dc3cda1a6069988

I also couldn’t figure out (if there is) a way to set default params so explicitly passing appropriate values (https://github.com/planningcenter/church-center-dreamin/blob/aa31e36118f8cf98a10e2b282dc3cda1a6069988/modules/LocationScreen.js#L116-L119 and https://github.com/planningcenter/church-center-dreamin/blob/aa31e36118f8cf98a10e2b282dc3cda1a6069988/modules/LocationScreen.js#L143-L146)

![location](https://user-images.githubusercontent.com/359871/34313619-18277f5c-e732-11e7-946b-4b689c932a71.gif)